### PR TITLE
Add primer design helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,17 @@ Install requirements with:
 ```bash
 pip install -r requirements.txt
 ```
+
+## Designing primers
+
+To automatically design PCR primers for the extracted CDS sequences run
+`design_primers.sh` from the `src` directory:
+
+```bash
+cd src
+bash design_primers.sh
+```
+
+The script installs the required dependencies (including `primer3-py`) and
+invokes `design_primers.py` for every `*_cds.fasta` in `../outputs/fastas`. The
+results are saved in `../outputs/primers`.

--- a/src/design_primers.sh
+++ b/src/design_primers.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+# Install dependencies
+pip install -r ../requirements.txt
+pip install primer3-py
+
+# Paths
+FASTA_DIR="../outputs/fastas"
+PARAMS="../src/params.json"
+OUT_DIR="../outputs/primers"
+
+mkdir -p "$OUT_DIR"
+
+# Run primer design for each CDS FASTA
+for fasta in "$FASTA_DIR"/*_cds.fasta; do
+  python ../src/design_primers.py "$fasta" "$PARAMS" "$OUT_DIR"
+done


### PR DESCRIPTION
## Summary
- add `src/design_primers.sh` to automate running `design_primers.py`
- document usage in README

## Testing
- `bash -n src/design_primers.sh`


------
https://chatgpt.com/codex/tasks/task_e_683fbbf22010832b8e3b955ad9a9ef7e