### PR TITLE
Improve primer design scripts

### DIFF
--- a/src/design_primers.py
+++ b/src/design_primers.py
@@ -1,84 +1,80 @@
-import sys, json, os
+import argparse
+import json
+import os
+import sys
+
 from Bio import SeqIO
 import primer3
 
-def load_config(file: str) -> dict:
-    """Load configuration from a JSON file."""	
-    with open(file) as f:
-        return json.load(f)
+def load_config(path: str) -> dict:
+    """Load configuration from a JSON file."""
+    with open(path) as fh:
+        return json.load(fh)
 
-def load_seq(fastafile: str) -> tuple:
-    """Load a sequence from a FASTA file. returns the sequence and its ID."""
-    rec = next(SeqIO.parse(fastafile, "fasta"))
-    return str(rec.seq), rec.id
+def load_seq(fastafile: str) -> tuple[str, str]:
+    """Return the sequence and its identifier from a FASTA file."""
+    record = next(SeqIO.parse(fastafile, "fasta"))
+    return str(record.seq), record.id
 
-def design(cfg,seq: str, id) -> list:
-    """Design primers for a given sequence based on configuration.
-    it returns the forward and reverse primers, their melting temperatures, and the product size."""
-    ## Prepare the arguments for primer3
-    seq_args = {
-        "SEQUENCE_ID": id,
-        "SEQUENCE_TEMPLATE": seq,
-    }
+def design(cfg: dict, seq: str, sid: str) -> list[dict]:
+    """Return a list of primers for the given sequence."""
+
+    seq_args = {"SEQUENCE_ID": sid, "SEQUENCE_TEMPLATE": seq}
     global_args = {
-        "PRIMER_TASK":       "generic",
+        "PRIMER_TASK": "generic",
         "PRIMER_NUM_RETURN": cfg["PRIMER_NUM_RETURN"],
-        "PRIMER_MIN_SIZE":   cfg["PRIMER_MIN_SIZE"],
-        "PRIMER_OPT_SIZE":   (cfg["PRIMER_MIN_SIZE"] + cfg["PRIMER_MAX_SIZE"]) // 2,
-        "PRIMER_MAX_SIZE":   cfg["PRIMER_MAX_SIZE"],
-        "PRIMER_MIN_GC":     cfg["PRIMER_MIN_GC_PERCENT"],
-        "PRIMER_MAX_GC":     cfg["PRIMER_MAX_GC_PERCENT"],
-        "PRIMER_MAX_TM":     cfg["PRIMER_MAX_TM"],
+        "PRIMER_MIN_SIZE": cfg["PRIMER_MIN_SIZE"],
+        "PRIMER_OPT_SIZE": (cfg["PRIMER_MIN_SIZE"] + cfg["PRIMER_MAX_SIZE"]) // 2,
+        "PRIMER_MAX_SIZE": cfg["PRIMER_MAX_SIZE"],
+        "PRIMER_MIN_GC": cfg["PRIMER_MIN_GC_PERCENT"],
+        "PRIMER_MAX_GC": cfg["PRIMER_MAX_GC_PERCENT"],
+        "PRIMER_MAX_TM": cfg["PRIMER_MAX_TM"],
     }
     if cfg.get("AVOID_GC_AT_3_PRIME"):
         global_args["PRIMER_3_END_GC_CLAMP"] = 0
 
-    # ``primer3`` exposes ``designPrimers``. Using keyword arguments would
-    # raise a ``TypeError`` because the function expects the dictionaries
-    # as positional parameters.  Calling the correct function name and
-    # passing the arguments positionally avoids runtime errors when
-    # generating the primer pairs.
-    res = primer3.bindings.designPrimers(
-        seq_args,
-        global_args,
-    )
+    res = primer3.bindings.designPrimers(seq_args, global_args)
 
     primers = []
     for i in range(cfg["PRIMER_NUM_RETURN"]):
         primers.append({
-            "id": id,
+            "id": sid,
             "forward": res[f"PRIMER_LEFT_{i}_SEQUENCE"],
-            "tm_fwd":  res[f"PRIMER_LEFT_{i}_TM"],
+            "tm_fwd": res[f"PRIMER_LEFT_{i}_TM"],
             "reverse": res[f"PRIMER_RIGHT_{i}_SEQUENCE"],
-            "tm_rev":  res[f"PRIMER_RIGHT_{i}_TM"],
-            "product": res[f"PRIMER_PAIR_{i}_PRODUCT_SIZE"]
+            "tm_rev": res[f"PRIMER_RIGHT_{i}_TM"],
+            "product": res[f"PRIMER_PAIR_{i}_PRODUCT_SIZE"],
         })
     return primers
 
-if __name__=="__main__":
-    # Example usage:
-    #   python design_primers.py <input.fasta> <params.json> <output_dir>
-    # The results will be written inside ``<output_dir>`` as
-    # ``resultados_<input>.json``.
-    if len(sys.argv)!=4:
-        print("Uso: design_primers.py <input.fasta> <params.json> <output_dir>")
-        sys.exit(1)
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Design PCR primers")
+    parser.add_argument("fasta", help="Input FASTA file")
+    parser.add_argument("params", help="JSON file with primer3 parameters")
+    parser.add_argument("output", help="Directory to store the results")
+    args = parser.parse_args(argv)
 
-    fasta, cfg_fn, out_fn = sys.argv[1], sys.argv[2], sys.argv[3]
-    seq, sid = load_seq(fasta)
-    cfg = load_config(cfg_fn)
-    primers = design( cfg, seq, sid)
+    seq, sid = load_seq(args.fasta)
+    cfg = load_config(args.params)
+    primers = design(cfg, seq, sid)
 
-    if out_fn:
-        os.makedirs(out_fn, exist_ok=True)
+    os.makedirs(args.output, exist_ok=True)
+    base = os.path.splitext(os.path.basename(args.fasta))[0]
+    out_fn = os.path.join(args.output, f"resultados_{base}.json")
 
-    base = os.path.splitext(os.path.basename(fasta))[0]
-    out_fn = os.path.join(out_fn, f"resultados_{base}.json")
-
-   
-    with open(out_fn, "w") as f:
-        json.dump({sid: primers}, f, indent=2)
+    with open(out_fn, "w") as fh:
+        json.dump({sid: primers}, fh, indent=2)
 
     print(f"→ {len(primers)} cebadores guardados en {out_fn}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except FileNotFoundError as exc:
+        sys.exit(f"Error: {exc}")
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        sys.exit(f"Unexpected error: {exc}")
 
   

--- a/src/design_primers.sh
+++ b/src/design_primers.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Install dependencies
 pip install -r ../requirements.txt
@@ -10,9 +10,21 @@ FASTA_DIR="../outputs/fastas"
 PARAMS="../src/params.json"
 OUT_DIR="../outputs/primers"
 
+if [[ ! -d "$FASTA_DIR" ]]; then
+  echo "Error: FASTA directory '$FASTA_DIR' does not exist" >&2
+  exit 1
+fi
+
+shopt -s nullglob
+fastas=("$FASTA_DIR"/*_cds.fasta)
+if (( ${#fastas[@]} == 0 )); then
+  echo "Error: no FASTA files found in $FASTA_DIR" >&2
+  exit 1
+fi
+
 mkdir -p "$OUT_DIR"
 
 # Run primer design for each CDS FASTA
-for fasta in "$FASTA_DIR"/*_cds.fasta; do
+for fasta in "${fastas[@]}"; do
   python ../src/design_primers.py "$fasta" "$PARAMS" "$OUT_DIR"
 done


### PR DESCRIPTION
## Summary
- refactor `design_primers.py`
  - drop redundant comments
  - use argparse and error handling
- harden `design_primers.sh` with basic checks

## Testing
- `python -m py_compile src/design_primers.py src/read_seq.py src/read_seq_ver1.py`
- `bash -n src/design_primers.sh`

------
https://chatgpt.com/codex/tasks/task_e_683fbf095120832b96ee19c3ed878936